### PR TITLE
Refactoring for new KubeHTTPClient.version() behavior

### DIFF
--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 import json
 import time
-import re
 
 from packaging.version import parse
 
@@ -12,13 +11,9 @@ from scheduler.exceptions import KubeException, KubeHTTPException
 class Deployment(Resource):
     api_prefix = 'apis'
 
-    def __sanitized_version(self):
-        """Remove non-numerics and non-decimal from our k8s API version"""
-        return parse(re.sub("[^0-9\.]", '', str(self.version())))
-
     @property
     def api_version(self):
-        if self.__sanitized_version() >= parse("1.9.0"):
+        if self.version() >= parse("1.9.0"):
             return 'apps/v1'
 
         return 'extensions/v1beta1'

--- a/rootfs/scheduler/tests/test_deployments.py
+++ b/rootfs/scheduler/tests/test_deployments.py
@@ -92,48 +92,40 @@ class DeploymentsTest(TestCase):
             Version('{}'.format(data))
 
     def test_deployment_api_version_1_9_and_up(self):
-        expected = 'apps/v1'
+        cases = ['1.12', '1.11', '1.10', '1.9']
+
         deployment = copy.copy(self.scheduler.deployment)
 
-        deployment.version = mock.MagicMock(return_value=parse("1.12+"))
-        self.assertEqual(expected, deployment.api_version, '1.12+ breaks')
+        expected = 'apps/v1'
 
-        deployment.version = mock.MagicMock(return_value=parse("1.11+"))
-        self.assertEqual(expected, deployment.api_version, '1.11+ breaks')
-
-        deployment.version = mock.MagicMock(return_value=parse("1.10+"))
-        self.assertEqual(expected, deployment.api_version, '1.10+ breaks')
-
-        deployment.version = mock.MagicMock(return_value=parse("1.9+"))
-        self.assertEqual(expected, deployment.api_version, '1.9+ breaks')
-
-        deployment.version = mock.MagicMock(return_value=parse("1.9"))
-        self.assertEqual(expected, deployment.api_version, '1.9 breaks')
+        for canonical in cases:
+            deployment.version = mock.MagicMock(return_value=parse(canonical))
+            actual = deployment.api_version
+            self.assertEqual(
+                    expected,
+                    actual,
+                    "{} breaks - expected {}, got {}".format(
+                        canonical,
+                        expected,
+                        actual))
 
     def test_deployment_api_version_1_8_and_lower(self):
-        expected = 'extensions/v1beta1'
+        cases = ['1.8', '1.7', '1.6', '1.5', '1.4', '1.3', '1.2']
+
         deployment = copy.copy(self.scheduler.deployment)
 
-        deployment.version = mock.MagicMock(return_value=parse("1.8"))
-        self.assertEqual(expected, deployment.api_version, '1.8 breaks')
+        expected = 'extensions/v1beta1'
 
-        deployment.version = mock.MagicMock(return_value=parse("1.7"))
-        self.assertEqual(expected, deployment.api_version, '1.7 breaks')
-
-        deployment.version = mock.MagicMock(return_value=parse("1.6"))
-        self.assertEqual(expected, deployment.api_version, '1.6 breaks')
-
-        deployment.version = mock.MagicMock(return_value=parse("1.5"))
-        self.assertEqual(expected, deployment.api_version, '1.5 breaks')
-
-        deployment.version = mock.MagicMock(return_value=parse("1.4"))
-        self.assertEqual(expected, deployment.api_version, '1.4 breaks')
-
-        deployment.version = mock.MagicMock(return_value=parse("1.3"))
-        self.assertEqual(expected, deployment.api_version, '1.3 breaks')
-
-        deployment.version = mock.MagicMock(return_value=parse("1.2"))
-        self.assertEqual(expected, deployment.api_version, '1.2 breaks')
+        for canonical in cases:
+            deployment.version = mock.MagicMock(return_value=parse(canonical))
+            actual = deployment.api_version
+            self.assertEqual(
+                    expected,
+                    actual,
+                    "{} breaks - expected {}, got {}".format(
+                        canonical,
+                        expected,
+                        actual))
 
     def test_create_failure(self):
         with self.assertRaises(

--- a/rootfs/scheduler/tests/test_kubehttpclient_version.py
+++ b/rootfs/scheduler/tests/test_kubehttpclient_version.py
@@ -1,0 +1,98 @@
+"""
+Unit tests for the Deis scheduler module.
+
+Run the tests with "./manage.py test scheduler"
+"""
+import requests
+import requests_mock
+from unittest import mock
+from packaging.version import parse
+
+from django.test import TestCase
+
+import scheduler
+
+
+def mock_session_for_version(blah=None):
+    return requests.Session()
+
+
+def connection_refused_matcher(request):
+    raise requests.ConnectionError("connection refused")
+
+
+@mock.patch('scheduler.get_session', mock_session_for_version)
+class KubeHTTPClientTest(TestCase):
+    """Tests kubernetes HTTP client version calls"""
+
+    def setUp(self):
+        self.adapter = requests_mock.Adapter()
+        self.url = 'http://versiontest.example.com'
+        self.path = '/version'
+
+        # use the real scheduler client.
+        self.scheduler = scheduler.KubeHTTPClient(self.url)
+        self.scheduler.session.mount(self.url, self.adapter)
+
+    def test_version_for_gke(self):
+        """
+        Ensure that version() sanitizes info from GKE clusters
+        """
+
+        cases = {
+                "1.12": {"major": "1", "minor": "12-gke"},
+                "1.10": {"major": "1", "minor": "10-gke"},
+                "1.9": {"major": "1", "minor": "9-gke"},
+                "1.8": {"major": "1", "minor": "8-gke"},
+                }
+
+        for canonical in cases:
+            resp = cases[canonical]
+            self.adapter.register_uri('GET', self.url + self.path, json=resp)
+
+            expected = parse(canonical)
+            actual = self.scheduler.version()
+
+            self.assertEqual(expected, actual, "{} breaks".format(resp))
+
+    def test_version_for_eks(self):
+        """
+        Ensure that version() sanitizes info from EKS clusters
+        """
+
+        cases = {
+                "1.12": {"major": "1", "minor": "12+"},
+                "1.10": {"major": "1", "minor": "10+"},
+                "1.9": {"major": "1", "minor": "9+"},
+                "1.8": {"major": "1", "minor": "8+"},
+                }
+
+        for canonical in cases:
+            resp = cases[canonical]
+            self.adapter.register_uri('GET', self.url + self.path, json=resp)
+
+            expected = parse(canonical)
+            actual = self.scheduler.version()
+
+            self.assertEqual(expected, actual, "{} breaks".format(resp))
+
+    def test_version_vanilla(self):
+        """
+        Ensure that version() sanitizes info from vanilla k8s clusters
+        """
+
+        cases = {
+                "1.12": {"major": "1", "minor": "12"},
+                "1.10": {"major": "1", "minor": "10"},
+                "1.9": {"major": "1", "minor": "9"},
+                "1.8": {"major": "1", "minor": "8"},
+                }
+
+        for canonical in cases:
+            resp = cases[canonical]
+            self.adapter.register_uri('GET', self.url + self.path, json=resp)
+
+            expected = parse(canonical)
+            actual = self.scheduler.version()
+
+            self.assertEqual(expected, actual, "{} breaks".format(resp))


### PR DESCRIPTION
This adds behavior tests for KubeHTTPClient's `version()` method, loosens up Deployment's `api_version` test to just focus on the things that it cares about, and refactors Deployment's `api_version` method to use the `version()` inherited from KubeHTTPClient.